### PR TITLE
Add a codec for Ingredient

### DIFF
--- a/src/main/java/xyz/nucleoid/codecs/MoreCodecs.java
+++ b/src/main/java/xyz/nucleoid/codecs/MoreCodecs.java
@@ -102,7 +102,7 @@ public final class MoreCodecs {
     public static final Codec<Ingredient> INGREDIENT = withJson(Ingredient::toJson, element -> {
         try {
             return DataResult.success(Ingredient.fromJson(element));
-        } catch (JsonParseException var2) {
+        } catch (JsonParseException e) {
             return DataResult.error(var2.getMessage());
         }
     });

--- a/src/main/java/xyz/nucleoid/codecs/MoreCodecs.java
+++ b/src/main/java/xyz/nucleoid/codecs/MoreCodecs.java
@@ -1,6 +1,7 @@
 package xyz.nucleoid.codecs;
 
 import com.google.gson.JsonElement;
+import com.google.gson.JsonParseException;
 import com.google.gson.JsonSyntaxException;
 import com.mojang.datafixers.util.Either;
 import com.mojang.serialization.Codec;
@@ -17,6 +18,7 @@ import net.minecraft.nbt.NbtCompound;
 import net.minecraft.nbt.NbtElement;
 import net.minecraft.nbt.NbtOps;
 import net.minecraft.predicate.BlockPredicate;
+import net.minecraft.recipe.Ingredient;
 import net.minecraft.registry.Registries;
 import net.minecraft.registry.Registry;
 import net.minecraft.registry.RegistryKey;
@@ -96,6 +98,14 @@ public final class MoreCodecs {
             return DataResult.error(e.getMessage());
         }
     });
+
+    public static final Codec<Ingredient> INGREDIENT = Codecs.JSON_ELEMENT.flatXmap(element -> {
+        try {
+            return DataResult.success(Ingredient.fromJson(element));
+        } catch (JsonParseException var2) {
+            return DataResult.error(var2.getMessage());
+        }
+    }, ingredient -> DataResult.success(ingredient.toJson()));
 
     public static <T> Codec<T[]> arrayOrUnit(Codec<T> codec, IntFunction<T[]> factory) {
         return listToArray(listOrUnit(codec), factory);

--- a/src/main/java/xyz/nucleoid/codecs/MoreCodecs.java
+++ b/src/main/java/xyz/nucleoid/codecs/MoreCodecs.java
@@ -99,13 +99,13 @@ public final class MoreCodecs {
         }
     });
 
-    public static final Codec<Ingredient> INGREDIENT = Codecs.JSON_ELEMENT.flatXmap(element -> {
+    public static final Codec<Ingredient> INGREDIENT = withJson(Ingredient::toJson, element -> {
         try {
             return DataResult.success(Ingredient.fromJson(element));
         } catch (JsonParseException var2) {
             return DataResult.error(var2.getMessage());
         }
-    }, ingredient -> DataResult.success(ingredient.toJson()));
+    });
 
     public static <T> Codec<T[]> arrayOrUnit(Codec<T> codec, IntFunction<T[]> factory) {
         return listToArray(listOrUnit(codec), factory);

--- a/src/main/java/xyz/nucleoid/codecs/MoreCodecs.java
+++ b/src/main/java/xyz/nucleoid/codecs/MoreCodecs.java
@@ -103,7 +103,7 @@ public final class MoreCodecs {
         try {
             return DataResult.success(Ingredient.fromJson(element));
         } catch (JsonParseException e) {
-            return DataResult.error(var2.getMessage());
+            return DataResult.error(e.getMessage());
         }
     });
 


### PR DESCRIPTION
# Motivation

Ingredients can only be de/serialised through fromJson/toJson methods, which can be annoying in a context where Codecs are being used, or when trying to serialise to NBT.

# Content

This PR adds a simple Codec which encodes/decodes an Ingredient, using MoreCodecs#withJson.